### PR TITLE
[Config] feature/global - Swagger 관련 세팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'	//swagger
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/tutorial/spring/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tutorial/spring/global/config/SwaggerConfig.java
@@ -1,0 +1,17 @@
+package com.tutorial.spring.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI(){
+        return new OpenAPI()
+                .info(new Info()
+                        .title("API")
+                        .description("API의 Docs와 테스트을 제공합니다.")
+                        .version("1.0.0"));
+    }
+}


### PR DESCRIPTION
## Swagger 세팅
- Spring Boot 3.3에 맞게 Swagger세팅
- API 테스트를 원활하게 하기 위함
- http://localhost:8080/swagger-ui/index.html 에서 확인 가능

**[설정 관련 자료]**
https://springdoc.org/