### PR TITLE
[Feature] feature/global - 공통 상태코드, 응답 설정 

### DIFF
--- a/src/main/java/com/tutorial/spring/global/common/code/StatusCode.java
+++ b/src/main/java/com/tutorial/spring/global/common/code/StatusCode.java
@@ -8,7 +8,7 @@ public class StatusCode {
     //성공 응답
     public static final int OK = 200;
     public static final int CREATED = 201;
-    public static final int Accepted = 202;
+    public static final int ACCEPTED = 202;
     public static final int NO_CONTENT = 204;
 
     //리다이렉션 메세지

--- a/src/main/java/com/tutorial/spring/global/common/code/StatusCode.java
+++ b/src/main/java/com/tutorial/spring/global/common/code/StatusCode.java
@@ -1,0 +1,29 @@
+package com.tutorial.spring.global.common.code;
+
+/**
+ * 상태 코드
+ * 참고 : https://developer.mozilla.org/ko/docs/Web/HTTP
+ */
+public class StatusCode {
+    //성공 응답
+    public static final int OK = 200;
+    public static final int CREATED = 201;
+    public static final int Accepted = 202;
+    public static final int NO_CONTENT = 204;
+
+    //리다이렉션 메세지
+    public static final int MULTIPLE_CHOICE = 300;
+    public static final int MOVED_PERMANENTLY = 301;
+
+    //클라이언트 에러 응답
+    public static final int BAD_REQUEST =  400;
+    public static final int UNAUTHORIZED = 401;
+    public static final int FORBIDDEN = 403;
+    public static final int NOT_FOUND = 404;
+
+    //서버 에러 응답
+    public static final int INTERNAL_SERVER_ERROR = 500;
+    public static final int NOT_IMPLEMENTED = 501;
+    public static final int BAD_GATEWAY = 502;
+    public static final int SERVICE_UNAVAILABLE = 503;
+}

--- a/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
+++ b/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
@@ -1,0 +1,34 @@
+package com.tutorial.spring.global.common.response;
+
+import lombok.Builder;
+
+/**
+ * 공통 API Response
+ */
+@Builder
+public class CommonResponse<T> {
+
+    // 응답 코드로 StatusCode에 정의됨
+    private int statusCode = 200;
+
+    // 응답 메세지
+    private final String message;
+
+    // 결과
+    private T data;
+
+    /**
+     * 필수값 확인을 위한 builder 재정의
+     *
+     * @param statusCode
+     * @param message
+     * @param data
+     */
+    public CommonResponseBuilder builder(int statusCode, String message, T data) {
+        //응답 메세지가 필수임
+        if(message == null || "".equals(message))
+            throw new IllegalArgumentException("response 메세지 누락");
+
+        return new CommonResponseBuilder().statusCode(statusCode).message(message).data(data);
+    }
+}

--- a/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
+++ b/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
@@ -1,5 +1,6 @@
 package com.tutorial.spring.global.common.response;
 
+import io.micrometer.common.util.StringUtils;
 import lombok.Builder;
 
 /**
@@ -26,8 +27,9 @@ public class CommonResponse<T> {
      */
     public CommonResponseBuilder builder(int statusCode, String message, T data) {
         //응답 메세지가 필수임
-        if(message == null || "".equals(message))
+        if(StringUtils.isEmpty(message)) {
             throw new IllegalArgumentException("response 메세지 누락");
+        }
 
         return new CommonResponseBuilder().statusCode(statusCode).message(message).data(data);
     }

--- a/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
+++ b/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 public class CommonResponse<T> {
 
     // 응답 코드로 StatusCode에 정의됨
-    private int statusCode = 200;
+    private final int statusCode;
 
     // 응답 메세지
     private final String message;

--- a/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
+++ b/src/main/java/com/tutorial/spring/global/common/response/CommonResponse.java
@@ -25,7 +25,7 @@ public class CommonResponse<T> {
      * @param message
      * @param data
      */
-    public CommonResponseBuilder builder(int statusCode, String message, T data) {
+    public CommonResponseBuilder builder(final int statusCode,final String message,final T data) {
         //응답 메세지가 필수임
         if(StringUtils.isEmpty(message)) {
             throw new IllegalArgumentException("response 메세지 누락");


### PR DESCRIPTION
## 공통 상태코드, 응답 설정
- StatusCode에 상태 코드를 설정
- 응답 클래스 추가

### * 고민한 부분
1. 파라미터 앞에 final를 붙이는 이유
CommonResponse의 빌더를 재정의할 때 **파라미터 앞에 final**를 붙임.
이를 통해 코드의 가독성을 높이고 불변성을 보장할 수 있음.
실수로 파라미터가 변경될 수 있는 잠재적 오류를 방지할 수도 있기 때문에 사용하는 것이 좋다고 판단.

2. 빌더에서 필수값을 지정하는 방법
- 빌더 메소드 재정의
builder 메소드를 재정의하여 필수값이 들어왔는지 검증
- NonNull 사용
필수값이 필요한 매개변수에 NonNull을 사용함. 
이 경우 해당 빌더를 사용할 때 필수값을 입력하지 않으면 NPE이 발생함.
-> 이런 이유 때문에 첫번째 방법을 택하게 됨

### * 고민이 필요한 부분
현재 CommonResponse에서는 3가지의 매개 변수를 가지고 있기 때문에 **빌더 패턴을 적용할 필요가 없지 않을까**에 대한 고민이 있음.
공통적으로 사용해야하고 변수명에 대한 변경이 있는 경우 빌더패턴의 영향도가 크기 때문에 
현재처럼 매개 변수의 수가 적고 영향도가 큰 경우 기존 방식을 택하는 것도 괜찮을 것 같음. 
