### PR TITLE
[Config] config/gradle-wrapper - gradle wrapper 관련 파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
 !**/src/main/**/build/
 !**/src/test/**/build/
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
## gradle wrapper 관련 파일 추가
Jenkins 파이프라인 설정 중에 아래와 같은 에러가 발생하여 gradle-wrapper.properties 파일을 .gitignore에 걸리지 않도록 수정함.
```
Exception in thread "main" java.lang.RuntimeException: Wrapper properties file '/var/jenkins_home/workspace/spring-tutorial/gradle/wrapper/gradle-wrapper.properties' does not exist.
	at org.gradle.wrapper.GradleWrapperMain.main(SourceFile:74)
```

### gradle wrapper를 사용하는 이유
1. 일관된 빌드 환경 보장
Gradle Wrapper는 프로젝트와 함께 체크인되는 작은 스크립트 세트입니다. 이 스크립트는 특정 버전의 Gradle을 자동으로 다운로드하고 실행합니다. 이를 통해 프로젝트를 빌드하는 모든 개발자와 CI 서버가 동일한 Gradle 버전을 사용하게 되어 빌드 환경의 일관성을 보장합니다.

2. 간편한 설정 및 실행
개발자는 Gradle을 사전에 설치할 필요 없이, 단지 ./gradlew 또는 gradlew.bat 스크립트를 실행하기만 하면 됩니다. Gradle Wrapper는 필요한 경우 자동으로 Gradle을 다운로드하고 설정합니다.

3. CI/CD 환경에서 편리함
CI/CD 서버에서도 Gradle을 사전에 설치할 필요가 없습니다. CI/CD 파이프라인에서 Gradle Wrapper를 사용하면 설정이 간단해지고, 특정 Gradle 버전을 명시적으로 사용함으로써 빌드 실패를 줄일 수 있습니다.

4. 버전 관리
프로젝트의 Gradle 버전이 변경되더라도, Gradle Wrapper 설정 파일(gradle-wrapper.properties)을 업데이트하면 됩니다. 이는 팀원들이나 CI 시스템이 새로운 버전을 사용하도록 쉽게 전환할 수 있게 합니다.

5. 플랫폼 독립성
Gradle Wrapper는 운영 체제에 독립적입니다. 프로젝트와 함께 제공되기 때문에 Windows, macOS, Linux 등 다양한 환경에서 동일하게 동작합니다.